### PR TITLE
Fix connector failure caused by Snort T&C acceptance page

### DIFF
--- a/snort-ip-blocklist-feed/connector.py
+++ b/snort-ip-blocklist-feed/connector.py
@@ -1,7 +1,7 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2023 Fortinet Inc
+Copyright (c) 2025 Fortinet Inc
 Copyright end
 """
 

--- a/snort-ip-blocklist-feed/info.json
+++ b/snort-ip-blocklist-feed/info.json
@@ -1,6 +1,6 @@
 {
   "name": "snort-ip-blocklist-feed",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "label": "Snort IP Blocklist Feed",
   "category": "Threat Intelligence",
   "description": "Snort is an open-source, free and lightweight network intrusion detection system (NIDS) software for Linux and Windows to detect emerging threats. This connector facilitates automated operations related to fetching the list indicators and ingestion of daily threat feeds.<br></br> This connector has a dependency on the <a href=\"/content-hub/all-content/?contentType=solutionpack&amp;tag=ThreatIntelManagement\" target=\"_blank\" rel=\"noopener\">Threat Intel Management Solution Pack</a>. Install the Solution Pack before enabling ingestion of Threat Feeds from this source.",
@@ -34,6 +34,17 @@
         "editable": true,
         "required": true,
         "value": "https://www.snort.org/downloads/ip-block-list"
+      },
+      {
+        "title": "Terms and Conditions",
+        "name": "terms",
+        "description": "Specifies whether the terms and conditions (https://www.snort.org/downloads/ip-block-list/terms) should be accepted. This option is enabled by default (set to True).",
+        "tooltip": "Specifies whether the terms and conditions (https://www.snort.org/downloads/ip-block-list/terms) should be accepted. This option is enabled by default (set to True).",
+        "type": "checkbox",
+        "required": false,
+        "editable": true,
+        "visible": true,
+        "value": true
       },
       {
         "title": "Verify SSL",

--- a/snort-ip-blocklist-feed/info.json
+++ b/snort-ip-blocklist-feed/info.json
@@ -7,7 +7,7 @@
   "publisher": "Fortinet",
   "cs_approved": true,
   "cs_compatible": true,
-  "help_online": "https://docs.fortinet.com/document/fortisoar/1.0.0/snort-ip-blocklist-feed/754/snort-ip-blocklist-feed-1-0-0",
+  "help_online": "",
   "icon_small_name": "small.png",
   "icon_large_name": "large.png",
   "ingestion_supported": true,

--- a/snort-ip-blocklist-feed/operations.py
+++ b/snort-ip-blocklist-feed/operations.py
@@ -32,7 +32,6 @@ def get_indicators(config):
         headers["Referer"] = terms_url
         accept_response = session.post(accept_url, data=form_data, headers=headers, timeout=10, verify=config.get('verify_ssl'))
         if accept_response.status_code != 200:
-            logger.error(f"Response content: {accept_response.text}")
             raise ConnectorError(f"Failed to accept terms (status {accept_response.status_code})")
         download_response = session.get(config.get('server_url'), headers=headers, timeout=10, verify=config.get('verify_ssl'))
         if download_response.status_code != 200:

--- a/snort-ip-blocklist-feed/operations.py
+++ b/snort-ip-blocklist-feed/operations.py
@@ -1,35 +1,44 @@
 """
 Copyright start
 MIT License
-Copyright (c) 2023 Fortinet Inc
+Copyright (c) 2025 Fortinet Inc
 Copyright end
 """
 
 import requests
 from connectors.core.connector import get_logger, ConnectorError
+from bs4 import BeautifulSoup
 
 logger = get_logger('snort-ip-blocklist-feed')
 
 
-def make_api_call(method="GET", config=None):
+def get_indicators(config):
     try:
-        server_url = config.get('server_url').strip('/')
-        if not server_url.startswith('https://') and not server_url.startswith('http://'):
-            server_url = "https://" + server_url
+        session = requests.Session()
+        headers = {}
+        terms_url = "https://www.snort.org/downloads/ip-block-list/terms"
+        terms_response = session.get(terms_url, headers=headers, timeout=10, verify=config.get('verify_ssl'))
 
-        response = requests.request(method=method, url=server_url, verify=config.get('verify_ssl'))
-        if response.ok:
-            return response
-        else:
-            if response.text != "":
-                err_resp = response.json()
-                failure_msg = err_resp['response_msg']
-                error_msg = 'Response [{0}:{1} Details: {2}]'.format(response.status_code, response.reason,
-                                                                     failure_msg if failure_msg else '')
-            else:
-                error_msg = 'Response [{0}:{1}]'.format(response.status_code, response.reason)
-            logger.error(error_msg)
-            raise ConnectorError(error_msg)
+        if terms_response.status_code != 200:
+            raise ConnectorError(f"Failed to fetch terms page (status {terms_response.status_code})")
+
+        soup = BeautifulSoup(terms_response.text, 'html.parser')
+        csrf_meta = soup.find("meta", attrs={"name": "csrf-token"})
+        if not csrf_meta:
+            raise ConnectorError("CSRF token not found in page.")
+        csrf_token = csrf_meta["content"]
+        accept_url = "https://www.snort.org/downloads/ip-block-list/accept-terms"
+        form_data = {"authenticity_token": csrf_token}
+        headers["Referer"] = terms_url
+        accept_response = session.post(accept_url, data=form_data, headers=headers, timeout=10, verify=config.get('verify_ssl'))
+        if accept_response.status_code != 200:
+            raise ConnectorError(f"Failed to accept terms (status {accept_response.status_code})")
+        download_response = session.get(config.get('server_url'), headers=headers, timeout=10, verify=config.get('verify_ssl'))
+        if download_response.status_code != 200:
+            raise ConnectorError(f"Failed to download IP block list (status {download_response.status_code})")
+        ip_list = download_response.content.decode('utf-8').split('\n')
+        ip_list = [ip for ip in ip_list if ip]
+        return ip_list
     except requests.exceptions.SSLError:
         logger.error('An SSL error occurred')
         raise ConnectorError('An SSL error occurred')
@@ -44,13 +53,6 @@ def make_api_call(method="GET", config=None):
         raise ConnectorError('There was an error while handling the request')
     except Exception as err:
         raise ConnectorError(str(err))
-
-
-def get_indicators(config):
-    response = make_api_call(config=config)
-    ip_list = response.content.decode('utf-8').split('\n')
-    ip_list = [ip for ip in ip_list if ip]
-    return ip_list
 
 
 def _check_health(config):

--- a/snort-ip-blocklist-feed/operations.py
+++ b/snort-ip-blocklist-feed/operations.py
@@ -32,6 +32,7 @@ def get_indicators(config):
         headers["Referer"] = terms_url
         accept_response = session.post(accept_url, data=form_data, headers=headers, timeout=10, verify=config.get('verify_ssl'))
         if accept_response.status_code != 200:
+            logger.error(f"Response content: {accept_response.text}")
             raise ConnectorError(f"Failed to accept terms (status {accept_response.status_code})")
         download_response = session.get(config.get('server_url'), headers=headers, timeout=10, verify=config.get('verify_ssl'))
         if download_response.status_code != 200:
@@ -57,6 +58,8 @@ def get_indicators(config):
 
 def _check_health(config):
     try:
+        if not config.get('terms', False):
+            raise ConnectorError('Please accept the Terms and Conditions.')
         if get_indicators(config):
             return True
     except Exception as e:

--- a/snort-ip-blocklist-feed/playbooks/playbooks.json
+++ b/snort-ip-blocklist-feed/playbooks/playbooks.json
@@ -4,7 +4,7 @@
     {
       "@context": "/api/3/contexts/WorkflowCollection",
       "@type": "WorkflowCollection",
-      "name": "Sample - Snort IP Blocklist Feed - 1.0.0",
+      "name": "Sample - Snort IP Blocklist Feed - 2.0.0",
       "description": "Sample playbooks for \"Snort IP Blocklist Feed\" connector. If you are planning to use any of the sample playbooks in your environment, ensure that you clone those playbooks and move them to a different collection, since the sample playbook collection gets deleted during connector upgrade and delete.",
       "visible": true,
       "image": "/api/3/images/72fe4ea9-2198-491d-894a-8f5ad6139493",
@@ -44,7 +44,7 @@
                 "name": "Snort IP Blocklist Feed",
                 "config": "",
                 "params": [],
-                "version": "1.0.0",
+                "version": "2.0.0",
                 "connector": "snort-ip-blocklist-feed",
                 "operation": "get_indicators",
                 "operationTitle": "Get Indicators"
@@ -270,7 +270,7 @@
                 "name": "Snort IP Blocklist Feed",
                 "config": "022754c2-48b5-45ea-b1e6-24703cdfc404",
                 "params": [],
-                "version": "1.0.0",
+                "version": "2.0.0",
                 "connector": "snort-ip-blocklist-feed",
                 "operation": "get_indicators",
                 "operationTitle": "Get Indicators",

--- a/snort-ip-blocklist-feed/release_notes.md
+++ b/snort-ip-blocklist-feed/release_notes.md
@@ -1,3 +1,4 @@
 #### What's Fixed
 
 - Resolved an issue where the connector was unable to fetch indicators due to the presence of a terms and conditions acceptance page on Snort. The connector now programmatically accepts the terms before attempting to download the IP block list.
+- Added new parameter `Terms and Conditions` in connector configuration.

--- a/snort-ip-blocklist-feed/release_notes.md
+++ b/snort-ip-blocklist-feed/release_notes.md
@@ -1,0 +1,3 @@
+#### What's Fixed
+
+- Resolved an issue where the connector was unable to fetch indicators due to the presence of a terms and conditions acceptance page on Snort. The connector now programmatically accepts the terms before attempting to download the IP block list.


### PR DESCRIPTION
#### Descriptions:

Resolved an issue where the connector was unable to fetch indicators due to the presence of a terms and conditions acceptance page on Snort. The connector now programmatically accepts the terms before attempting to download the IP block list.

#### UTC:

Verified the fix.

